### PR TITLE
Add optional result summarization

### DIFF
--- a/.actor/input_schema.json
+++ b/.actor/input_schema.json
@@ -18,6 +18,12 @@
             "editor": "select",
             "enum": ["gpt-4o-mini", "gpt-4o"],
             "default": "gpt-4o"
+        },
+        "summarizeResults": {
+            "title": "Summarize results with LLM",
+            "type": "boolean",
+            "description": "Generate a short summary of the scraped contact details",
+            "default": false
         }
     },
     "required": ["query"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The Agent has two main tools:
 Given a user query with a URL, the Agent uses the Contact Details Scraper to retrieve the contact information and optionally summarizes the data.
 The Agent can decide how to handle the data—whether to process it further or skip summarization if it's not necessary.
 
+### Summarization
+
+Set `summarizeResults` to `true` in the Actor input to generate a short summary of the scraped contact details using the configured OpenAI model. When the flag is omitted or `false`, only raw results are stored.
+
 ### Sample queries:
 
 - Find contact details for `apify.com` and provide raw results.

--- a/docs/REQUEST_FLOW.md
+++ b/docs/REQUEST_FLOW.md
@@ -7,10 +7,11 @@ This document explains how a request travels through the project from the moment
 1. **Client input** – The Actor is started via the Apify platform or the local CLI and receives a JSON input. Entry points are `src/__main__.py` for the platform and `src/cli.py` for local runs.
 2. **Adapter layer** – Depending on the environment, either `ApifyAdapter` or `LocalAdapter` implements the `PlatformAdapter` interface. The adapter fetches the input and is responsible for pushing data back.
 3. **Main workflow** – `main` in [`src/main.py`](../src/main.py) validates the input and calls `run_linkedin_crawler`.
-4. **Crawler** – `run_linkedin_crawler` in [`src/crawler/linkedin.py`](../src/crawler/linkedin.py) handles the crawling. In a more complete setup it may invoke `run_agent` to use the tools defined in [`src/agent.py`](../src/agent.py).
-5. **Agent tools** – `run_agent` registers tools such as `call_contact_details_scraper` and `summarize_contact_information` from [`src/tools.py`](../src/tools.py).
-6. **Contact Details Scraper** – `call_contact_details_scraper` runs another Apify Actor and retrieves its dataset results using `ApifyClientAsync.dataset().list_items()`.
-7. **Dataset storage** – The adapter's `push_data` method writes the final data back to the Apify dataset.
+4. **Crawler** – `run_linkedin_crawler` in [`src/crawler/linkedin.py`](../src/crawler/linkedin.py) handles the crawling.
+5. **Summarization** – When `summarizeResults` is enabled, `main` invokes `run_agent` with the collected contacts to produce a short summary.
+6. **Agent tools** – `run_agent` registers tools such as `call_contact_details_scraper` and `summarize_contact_information` from [`src/tools.py`](../src/tools.py).
+7. **Contact Details Scraper** – `call_contact_details_scraper` runs another Apify Actor and retrieves its dataset results using `ApifyClientAsync.dataset().list_items()`.
+8. **Dataset storage** – The adapter's `push_data` method writes the final data back to the Apify dataset.
 
 ## Sequence diagram
 
@@ -27,9 +28,9 @@ sequenceDiagram
     C->>A: Provide JSON input
     A->>M: get_input()
     M->>R: run_linkedin_crawler()
-    R->>AG: run_agent() [optional]
-    AG->>S: call_contact_details_scraper()
-    S-->>D: write dataset items
+    R->>S: call_contact_details_scraper()
+    S-->>M: raw results
+    M->>AG: run_agent() [summarizeResults]
     AG->>A: summarize_contact_information()
     M->>A: push_data()
     A-->>D: stored result

--- a/input.json
+++ b/input.json
@@ -1,5 +1,6 @@
 {
   "query": "https://www.linkedin.com/company/apifytech/",
   "maxDepth": 2,
-  "includeSocials": true
+  "includeSocials": true,
+  "summarizeResults": false
 }

--- a/src/main.py
+++ b/src/main.py
@@ -44,6 +44,17 @@ async def main(adapter):
             max_depth=data.maxDepth,
             include_socials=data.includeSocials,
         )
+
+        if getattr(data, "summarizeResults", False):
+            llm = OpenAI(model=str(data.modelName), temperature=0)
+            summary = await run_agent(
+                None,
+                llm=llm,
+                contact_information=result["results"],
+                verbose=True,
+            )
+            result["summary"] = summary
+
         await adapter.push_data(result)
     except Exception as e:
         await adapter.fail('Failed to process query', e)
@@ -59,7 +70,7 @@ async def check_inputs(actor_input: dict) -> None:
         await Actor.fail(status_message=msg)
 
 
-async def run_query(query: str, model_name: str) -> AgentChatResponse | None:
+async def run_query(query: str, model_name: str) -> str | None:
     """
     Executes a query using the LlamaIndex Agent with the specified OpenAI model.
     
@@ -68,7 +79,7 @@ async def run_query(query: str, model_name: str) -> AgentChatResponse | None:
         model_name (str): The name of the OpenAI model to use.
     
     Returns:
-        AgentChatResponse | None: The agent's response if successful; otherwise, None if an error occurs.
+        str | None: The agent's response if successful; otherwise, None if an error occurs.
     """
     llm = OpenAI(model=str(model_name), temperature=0)
     try:

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -7,3 +7,7 @@ class ActorInput(BaseModel):
     modelName: str = Field(default="gpt-4o", description="OpenAI model name")
     maxDepth: int = Field(default=2, ge=1, description="Crawling depth")
     includeSocials: bool = Field(default=True, description="Return social profiles")
+    summarizeResults: bool = Field(
+        default=False,
+        description="Summarize scraped contact data using the LLM",
+    )


### PR DESCRIPTION
## Summary
- allow `run_agent` to summarize existing contact data
- call `run_agent` from `main` when `summarizeResults` input flag is enabled
- document summarization in README and request flow docs
- update input schema and example input

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_6854780f5b188333b8b738fcf8df9208