### PR TITLE
Add Supabase admin authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,17 @@ See `.env.example` for all environment variables.
 
 ## 🔒 Security
 
-- **No authentication** by default (add API keys/proxy if needed)
-- All results/logs stored in `./data/jobs` (mount as a volume for persistence in Docker)
+- The API now requires a valid Supabase JWT token with the `admin` role.
+- Set `SUPABASE_JWT_SECRET` in the server environment to your project's JWT secret so tokens can be verified.
+- Clients should send the token in the `Authorization` header as `Bearer <token>`.
+- All results/logs are stored in `./data/jobs` (mount as a volume for persistence in Docker)
+
+### Getting a token
+
+Log in to your Supabase project and generate a user session token (e.g. via the
+Supabase dashboard or `supabase-js` client). Ensure the user has the `admin`
+role either through `app_metadata.roles` or your own role table. Use that JWT
+when calling the API endpoints.
 
 ---
 

--- a/env.example
+++ b/env.example
@@ -27,3 +27,6 @@ CONCURRENCY=2
 MAX_RETRIES=3
 TIMEOUT_SECS=60
 OWNER_EMAIL=user@example.com
+
+# JWT secret for verifying Supabase tokens
+SUPABASE_JWT_SECRET=your-jwt-secret-here

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ fastapi
 uvicorn
 redis
 requests
+python-jose[cryptography]
+python-multipart

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,40 @@
+import os
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+from jose import jwt
+
+# Set secret before importing app
+os.environ["SUPABASE_JWT_SECRET"] = "testsecret"
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.server import app, jobdb
+
+client = TestClient(app)
+
+def create_token(admin: bool):
+    payload = {"sub": "123", "email": "user@example.com"}
+    if admin:
+        payload["app_metadata"] = {"roles": ["admin"]}
+    token = jwt.encode(payload, os.environ["SUPABASE_JWT_SECRET"], algorithm="HS256")
+    return token
+
+def test_missing_auth():
+    r = client.get("/jobs")
+    assert r.status_code == 422
+
+def test_invalid_token():
+    r = client.get("/jobs", headers={"Authorization": "Bearer bad"})
+    assert r.status_code == 401
+
+def test_non_admin_token():
+    token = create_token(False)
+    r = client.get("/jobs", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 403
+
+def test_admin_token():
+    token = create_token(True)
+    jobdb.list_jobs = lambda owner_email=None: []
+    r = client.get("/jobs", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200
+


### PR DESCRIPTION
## Summary
- secure API endpoints with Supabase JWT checking
- install `python-jose` and `python-multipart`
- document token setup and usage
- expose `SUPABASE_JWT_SECRET` in example env
- test authorization logic for jobs endpoint

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f02542e808333922e7995ee97f892